### PR TITLE
Removendo PITest do Build

### DIFF
--- a/.github/workflows/commit-stage.yml
+++ b/.github/workflows/commit-stage.yml
@@ -28,14 +28,8 @@ jobs:
         run: |
           chmod +x gradlew
           ./gradlew build
-#          ./gradlew pitest
           ./gradlew bootBuildImage
 
-#      - name: Upload PITest report
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: pitest-report
-#          path: build/reports/pitest
 
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3


### PR DESCRIPTION
Removi o Pitest e o upload do arquivo estava muito lento.
Implementando o commit-stage para publicar direto no repositorio do amazon ECR e atualizar o KUSTOMIZE no repositorio airline-deployment que está sendo monitorado pelo argoCD.